### PR TITLE
[codex] add npm release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: chess
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: chess/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test package
+        run: npm test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,37 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: chess
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: chess/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish package
+        run: npm publish --access public --provenance

--- a/chess/package-lock.json
+++ b/chess/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@jacksonthall22/chess.ts",
+  "version": "0.1.11",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@jacksonthall22/chess.ts",
+      "version": "0.1.11",
+      "license": "SEE LICENSE IN LICENSE.txt"
+    }
+  }
+}

--- a/chess/package.json
+++ b/chess/package.json
@@ -48,8 +48,9 @@
     }
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc"
+    "build": "tsc",
+    "test": "npm run build",
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/chess/tsconfig.json
+++ b/chess/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */


### PR DESCRIPTION
This PR makes the npm package build and release path reproducible.

Previously, `npm test` always failed because it was the default placeholder script, there was no lockfile for `npm ci`, and releases depended on manual npm publishing. That made it hard to add CI or verify packaging before a release.

The package now has a lockfile, uses `npm run build` as the test command, and runs the build from `prepack` so manual `npm pack`/`npm publish` regenerate `dist/`. I also bumped the TypeScript target from ES2020 to ES2022 because the existing PGN code uses `Array.prototype.at()`, which otherwise makes the real build fail.

The new CI workflow installs from `chess/package-lock.json` and runs `npm test` for pull requests and pushes to `main`. The publish workflow runs from the `chess/` subdirectory on GitHub release publication and publishes to npm with provenance via trusted publishing/OIDC.

Validation run locally:

- `npm ci` from `chess/`
- `npm test` from `chess/`
- `npm pack --dry-run` from `chess/`

Before relying on release publishing, configure npm trusted publishing for `@jacksonthall22/chess.ts` with repository `jacksonthall22/chess.ts` and workflow `npm-publish.yml`.
